### PR TITLE
Fix for exception when doing Pairwise on empty collection

### DIFF
--- a/src/Tests/Collections/PairwiseTests.cs
+++ b/src/Tests/Collections/PairwiseTests.cs
@@ -25,5 +25,13 @@ namespace Tests.Destructure
             Assert.Equal(new[] { Tuple.Create(0, 1), Tuple.Create(1, 2), Tuple.Create(2, 3) },
                 result.ToArray());
         }
+
+        [Fact]
+        public void ShouldHandleEmptyCollection()
+        {
+            var emptyList = new string[0];
+            var result = emptyList.Pairwise(Tuple.Create).ToList();
+            Assert.Empty(result);
+        }
     }
 }

--- a/src/With/Linq/EnumerableExtensions.cs
+++ b/src/With/Linq/EnumerableExtensions.cs
@@ -11,7 +11,12 @@ namespace With.Linq
        this IEnumerable<T> self, Func<T, T, TResult> func)
         {
             var enumerator = self.GetEnumerator();
-            enumerator.MoveNext();
+
+            if (!enumerator.MoveNext())
+            {
+                yield break;
+            }
+            
             var last = enumerator.Current;
             for (; enumerator.MoveNext();)
             {


### PR DESCRIPTION
When doing `.Pairwise` on an empty collection you used to get an InvalidOperationException.