### PR TITLE
When there are missing ctor arguments should throw an exception

### DIFF
--- a/src/WithFs/Types.fs
+++ b/src/WithFs/Types.fs
@@ -31,3 +31,6 @@ type NameAndValue = System.Collections.Generic.KeyValuePair<string, obj>
 
 type MissingValueException(name:string)=
     inherit Exception(String.Format("Missing value named: {0}", name))
+
+type MissingConstructorParameterException(name:string)=
+    inherit Exception(String.Format("Missing constructor parameter for property named: {0}", name))

--- a/tests/Tests/With/Clone_an_instance_into_the_same_type.cs
+++ b/tests/Tests/With/Clone_an_instance_into_the_same_type.cs
@@ -49,23 +49,18 @@ namespace Tests.With
              Prepare.Copy<CustomerWithEmptyCtor, int, string>((m, v1, v2) => m.Id == v1 && m.Name == v2));
 
         [Theory, AutoData]
-        public void A_class_with_empty_ctor(
+        public void A_class_with_empty_ctor_and_a_longer_ctor_should_use_the_one_with_the_most_parameters(
             CustomerWithEmptyCtor instance, int newInt, string newString)
         {
             var ret = EmptyCtorIdAndNameCopy.Value.Copy(instance, newInt, newString);
             Assert.Equal(newInt, ret.Id);
             Assert.Equal(newString, ret.Name);
         }
-        public class CustomerWithEmptyCtor : Customer
+        [Fact]
+        public void A_class_with_a_missing_constructor_parameter_should_give_an_exception_on_build()
         {
-            public CustomerWithEmptyCtor()
-                : this(-1, null, new string[0])
-            {
-            }
-            public CustomerWithEmptyCtor(int id, string name, IEnumerable<string> preferences)
-                : base(id, name, preferences)
-            {
-            }
+            Assert.Throws<MissingConstructorParameterException> (()=>
+                LensBuilder<CustomerWithMissingConstructorParameter>.Of( m=> m.Id).And(m=>m.Name).Build());
         }
     }
 }

--- a/tests/Tests/With/TestData/CustomerWithEmptyCtor.cs
+++ b/tests/Tests/With/TestData/CustomerWithEmptyCtor.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Tests.With.TestData
+{
+    public class CustomerWithEmptyCtor : Customer
+    {
+        public CustomerWithEmptyCtor()
+            : this(-1, null, new string[0])
+        {
+        }
+        public CustomerWithEmptyCtor(int id, string name, IEnumerable<string> preferences)
+            : base(id, name, preferences)
+        {
+        }
+    }
+}

--- a/tests/Tests/With/TestData/CustomerWithMissingConstructorParameter.cs
+++ b/tests/Tests/With/TestData/CustomerWithMissingConstructorParameter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tests.With.TestData
+{
+    public class CustomerWithMissingConstructorParameter
+    {
+        private readonly int id;
+        private readonly string name;
+        private readonly IEnumerable<string> preferences;
+        public CustomerWithMissingConstructorParameter(int id,  IEnumerable<string> preferences)
+        {
+            this.id = id;
+            this.name = "named";
+            this.preferences = preferences;
+        }
+        public int Id { get { return id; } private set { throw new Exception(); } }
+        public string Name { get { return name; } private set { throw new Exception(); } }
+        public IEnumerable<string> Preferences { get { return preferences; } private set { throw new Exception(); } }
+    }
+}

--- a/tests/TestsFs/Clone_an_instance_into_the_same_type.fs
+++ b/tests/TestsFs/Clone_an_instance_into_the_same_type.fs
@@ -19,3 +19,8 @@ type ``Clone an instance into the same type``()=
         let ret = idAndNameCopy.Value.Copy(myClass,newIntValue,newStrValue)
         Assert.Equal(newIntValue, ret.id)
         Assert.Equal(newStrValue, ret.name)
+
+    [<Theory; AutoData>]
+    member this.``A class with a missing constructor parameter should give an exception on build`` (myClass:Customer, newIntValue:int, newStrValue:string)=
+        Assert.Throws<MissingConstructorParameterException> (fun ()->
+            LensBuilder<CustomerWithMissingCtorArgument>.Of( fun m v1 v2-> m.id = v1 && m.name = v2).Build() |> ignore ) 

--- a/tests/TestsFs/Customer.fs
+++ b/tests/TestsFs/Customer.fs
@@ -3,3 +3,6 @@ open System.Collections.Generic
 type Customer(id:int, name:string)=
     member val id=id
     member val name= name
+type CustomerWithMissingCtorArgument(id:int)=
+    member val id=id
+    member val name= "named"


### PR DESCRIPTION
This fixes #58 