### PR TITLE
Lens on constructor alias

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,23 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>6.0.0</VersionPrefix>
-        <VersionSuffix></VersionSuffix>
+        <VersionPrefix>6.1.0</VersionPrefix>
+        <VersionSuffix>beta-1</VersionSuffix>
         <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
         <Version Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</Version>
         <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
         <FileVersion>$(VersionPrefix).0</FileVersion>
+
+        <Authors>Oskar Gewalli</Authors>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/wallymathieu/with</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/wallymathieu/with.git</RepositoryUrl>
+        <PackageTags>copy;clone;with;Immutable;Extensions</PackageTags>
+    
+        <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
+        <Description>Extensions to make c# easier to use when doing functional code. Copy update expressions. Helper extensions.</Description>
+        <Copyright>Copyright 2020</Copyright>
+    
+        <PackageReleaseNotes>Possible to create lenses on types with constructor methods.</PackageReleaseNotes>
 
         <FSharpCoreVersion>4.5.4</FSharpCoreVersion>
     </PropertyGroup>

--- a/src/With/Builders.fs
+++ b/src/With/Builders.fs
@@ -2,6 +2,7 @@ namespace With
 open System
 open System.Linq.Expressions
 open With.Lenses
+open With.Lenses.Internals
 open With.Internals
 /// Helper type to create lenses
 type Lens<'T>=
@@ -40,7 +41,21 @@ type LensBuilder<'T,'U>(built:DataLens<'T,'U>, opt:DataLensOptions)=
     member __.Current = built
 
 /// LensBuilder in order to simplify building lenses in c#
-type LensBuilder<'T>()=
+type LensBuilder<'T>(opt:DataLensOptions)=
+    member __.Of(lens:DataLens<'T, 'U>) =
+        LensBuilder<'T,'U>(lens, opt)
+    /// Create a lensbuilder, created from the expression and the base type
+    member __.Of(expr:Expression<Func<'T, 'U>> ) =
+        LensBuilder<'T,'U>(Expressions.withMemberAccess opt expr, opt)
+    /// Create a lensbuilder, created from the expression and the base type
+    member __.Of(expr:Expression<Func<'T, 'U, bool>> ) =
+        LensBuilder<'T,'U>(Expressions.withEqualEqualOrCall opt expr, opt)
+    /// Create a lensbuilder, created from the expression and the base type
+    member __.Of(expr:Expression<Func<'T, 'U1, 'U2, bool>>) =
+        LensBuilder<'T,struct('U1*'U2)>(Expressions.withEqualEqualOrCall2 opt expr, opt)
+
+    static member Constructors(constructors:string array)=
+        LensBuilder<'T>(DataLensOptions.Create constructors)
     /// Create a lensbuilder, created from the lens
     static member Of(lens:DataLens<'T, 'U> ) =
         LensBuilder<'T,'U>(lens, DataLensOptions.Empty)
@@ -56,6 +71,8 @@ type LensBuilder<'T>()=
     static member Of(expr:Expression<Func<'T, 'U1, 'U2, bool>>) =
         let opt = DataLensOptions.Empty
         LensBuilder<'T,struct('U1*'U2)>(Expressions.withEqualEqualOrCall2 opt expr, opt)
+
+
 
 
 open System.Runtime.CompilerServices

--- a/src/With/Builders.fs
+++ b/src/With/Builders.fs
@@ -7,35 +7,35 @@ open With.Internals
 type Lens<'T>=
     /// Create a lens, created from the expression and the base type
     static member Of(expr:Expression<Func<'T, 'TValue>> ) : DataLens<'T,'TValue>=
-        Expressions.withMemberAccess expr
+        Expressions.withMemberAccess DataLensOptions.Empty expr
     /// Create a lens, created from the expression and the base type
     static member Of(expr:Expression<Func<'T, 'TValue, bool>> ) : DataLens<'T,'TValue>=
-        Expressions.withEqualEqualOrCall expr
+        Expressions.withEqualEqualOrCall DataLensOptions.Empty expr
     /// Create a lens, created from the expression and the base type
     static member Of(expr:Expression<Func<'T, 'TValue1, 'TValue2, bool>>) : DataLens<'T,struct('TValue1*'TValue2)>=
-        Expressions.withEqualEqualOrCall2 expr
+        Expressions.withEqualEqualOrCall2 DataLensOptions.Empty expr
 
 /// LensBuilder in order to simplify building lenses in c#
-type LensBuilder<'T,'U>(built:DataLens<'T,'U>)=
+type LensBuilder<'T,'U>(built:DataLens<'T,'U>, opt:DataLensOptions)=
     /// Combine existing lens with another lens
     member __.And(lens: DataLens<'T, 'U2>) =
-        LensBuilder<'T,struct('U*'U2)>(DataLens.combine built lens)
+        LensBuilder<'T,struct('U*'U2)>(DataLens.combine built lens, opt)
     /// Combine existing lens with expression representing another lens
     member __.And(expr: Expression<Func<'T, 'U2>>) =
-        LensBuilder<'T,struct('U*'U2)>(DataLens.combine built <| Expressions.withMemberAccess expr)
+        LensBuilder<'T,struct('U*'U2)>(DataLens.combine built <| Expressions.withMemberAccess opt expr, opt)
     /// Combine existing lens with expression representing another lens
     member __.And(expr:Expression<Func<'T, 'U2, bool>> ) =
-        LensBuilder<'T,struct('U*'U2)>(DataLens.combine built <| Expressions.withEqualEqualOrCall expr)
+        LensBuilder<'T,struct('U*'U2)>(DataLens.combine built <| Expressions.withEqualEqualOrCall opt expr, opt)
     /// Combine existing lens with expression representing another lens
     member __.And(expr:Expression<Func<'T, 'U2, 'U3, bool>>) =
-        LensBuilder<'T,struct('U * struct('U2*'U3))>(DataLens.combine built <| Expressions.withEqualEqualOrCall2 expr)
+        LensBuilder<'T,struct('U * struct('U2*'U3))>(DataLens.combine built <| Expressions.withEqualEqualOrCall2 opt expr, opt)
     /// Compose existing lens with expression representing deeper lens
     member __.Then(expr: Expression<Func<'U, 'V>>) =
-        let next = Expressions.withMemberAccess expr
-        LensBuilder<'T, 'V>(DataLens.compose next built)
+        let next = Expressions.withMemberAccess opt expr
+        LensBuilder<'T, 'V>(DataLens.compose next built, opt)
     /// Compose existing lens with deeper lens
     member __.Then(next: DataLens<'U, 'V>) =
-        LensBuilder<'T, 'V>(DataLens.compose next built)
+        LensBuilder<'T, 'V>(DataLens.compose next built, opt)
     /// Current lens
     member __.Current = built
 
@@ -43,16 +43,19 @@ type LensBuilder<'T,'U>(built:DataLens<'T,'U>)=
 type LensBuilder<'T>()=
     /// Create a lensbuilder, created from the lens
     static member Of(lens:DataLens<'T, 'U> ) =
-        LensBuilder<'T,'U>(lens)
+        LensBuilder<'T,'U>(lens, DataLensOptions.Empty)
     /// Create a lensbuilder, created from the expression and the base type
     static member Of(expr:Expression<Func<'T, 'U>> ) =
-        LensBuilder<'T,'U>(Expressions.withMemberAccess expr)
+        let opt = DataLensOptions.Empty
+        LensBuilder<'T,'U>(Expressions.withMemberAccess opt expr, opt)
     /// Create a lensbuilder, created from the expression and the base type
     static member Of(expr:Expression<Func<'T, 'U, bool>> ) =
-        LensBuilder<'T,'U>(Expressions.withEqualEqualOrCall expr)
+        let opt = DataLensOptions.Empty
+        LensBuilder<'T,'U>(Expressions.withEqualEqualOrCall opt expr, opt)
     /// Create a lensbuilder, created from the expression and the base type
     static member Of(expr:Expression<Func<'T, 'U1, 'U2, bool>>) =
-        LensBuilder<'T,struct('U1*'U2)>(Expressions.withEqualEqualOrCall2 expr)
+        let opt = DataLensOptions.Empty
+        LensBuilder<'T,struct('U1*'U2)>(Expressions.withEqualEqualOrCall2 opt expr, opt)
 
 
 open System.Runtime.CompilerServices

--- a/src/With/DataLens.fs
+++ b/src/With/DataLens.fs
@@ -3,6 +3,9 @@ open System
 open With
 open System.ComponentModel
 
+type DataLensOptions(constructorAlias:string array)=
+    member __.ConstructorAlias = constructorAlias
+
 /// Copy of Lens definition from <a href="https://github.com/fsprojects/FSharpx.Extras/blob/master/src/FSharpx.Extras/Lens.fs">FSharpx.Extras</a>
 /// A lens is sort of like a property for immutable data on steroids.
 /// You can compose and combine lenses

--- a/src/With/DataLens.fs
+++ b/src/With/DataLens.fs
@@ -5,6 +5,7 @@ open System.ComponentModel
 
 type DataLensOptions(constructorAlias:string array)=
     member __.ConstructorAlias = constructorAlias
+    static member Empty=DataLensOptions([||])
 
 /// Copy of Lens definition from <a href="https://github.com/fsprojects/FSharpx.Extras/blob/master/src/FSharpx.Extras/Lens.fs">FSharpx.Extras</a>
 /// A lens is sort of like a property for immutable data on steroids.
@@ -43,37 +44,37 @@ module DataLens =
     let inline internal composeUntyped (l1: DataLens) (l2: DataLens) = compose l1 l2
     /// Split a 2-tuples into a 3-tuple
     let ofTuple(): DataLens<struct(struct('v1 * 'v2) * 'v3),struct( 'v1 * 'v2 * 'v3)> =
-        { get = fun struct(struct(v1, v2), v3) -> (v1, v2, v3)
-          set = fun struct(v1, v2, v3) _ -> ((v1, v2), v3) }
+        { get = fun struct(struct(v1, v2), v3) -> struct(v1, v2, v3)
+          set = fun struct(v1, v2, v3) _ -> struct(struct(v1, v2), v3) }
 
     /// Split a cons combination of 2 2-tuples into a 3-tuple
     let ofLeftTuple(): DataLens<struct(struct('v1 * 'v2) * 'v3), struct( 'v1 * 'v2 * 'v3)> =
-        { get = fun struct(struct(v1, v2), v3) -> (v1, v2, v3)
-          set = fun struct(v1, v2, v3) _ -> ((v1, v2), v3) }
+        { get = fun struct(struct(v1, v2), v3) -> struct(v1, v2, v3)
+          set = fun struct(v1, v2, v3) _ -> struct(struct(v1, v2), v3) }
     /// Split a cons combination of 2 2-tuples into a 4-tuple
     let ofLeftTuple2(): DataLens<struct(struct(struct('v1 * 'v2) * 'v3) * 'v4), struct('v1 * 'v2 * 'v3 * 'v4)> =
-        { get = fun struct(struct(struct(v1, v2), v3), v4) -> (v1, v2, v3, v4)
-          set = fun struct(v1, v2, v3, v4) _ -> (((v1, v2), v3), v4) }
+        { get = fun struct(struct(struct(v1, v2), v3), v4) -> struct(v1, v2, v3, v4)
+          set = fun struct(v1, v2, v3, v4) _ -> struct(struct(struct(v1, v2), v3), v4) }
     /// Split a cons combination of 3 2-tuples into a 5-tuple
     let ofLeftTuple3(): DataLens<struct(struct(struct(struct('v1 * 'v2) * 'v3) * 'v4)*'v5), struct('v1 * 'v2 * 'v3 * 'v4 * 'v5)> =
-        { get = fun struct(struct(struct(struct(v1, v2), v3), v4),v5) -> (v1, v2, v3, v4, v5)
-          set = fun struct(v1, v2, v3, v4, v5) _ -> ((((v1, v2), v3), v4), v5) }
+        { get = fun struct(struct(struct(struct(v1, v2), v3), v4),v5) -> struct(v1, v2, v3, v4, v5)
+          set = fun struct(v1, v2, v3, v4, v5) _ -> struct(struct(struct(struct(v1, v2), v3), v4), v5) }
     /// Split a cons combination of 4 2-tuples into a 6-tuple
     let ofLeftTuple4(): DataLens<struct(struct(struct(struct(struct('v1 * 'v2) * 'v3) * 'v4)*'v5)*'v6), struct('v1 * 'v2 * 'v3 * 'v4 * 'v5 * 'v6)> =
-        { get = fun struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6) -> (v1, v2, v3, v4, v5,v6)
-          set = fun struct(v1, v2, v3, v4, v5, v6) _ -> (((((v1, v2), v3), v4),v5),v6) }
+        { get = fun struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6) -> struct(v1, v2, v3, v4, v5,v6)
+          set = fun struct(v1, v2, v3, v4, v5, v6) _ -> struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6) }
     /// Split a cons combination of 5 2-tuples into a 7-tuple
     let ofLeftTuple5(): DataLens<struct(struct(struct(struct(struct(struct('v1 * 'v2) * 'v3) * 'v4)*'v5)*'v6)*'v7), struct('v1 * 'v2 * 'v3 * 'v4 * 'v5 * 'v6 * 'v7)> =
-        { get = fun struct(struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6),v7)-> (v1, v2, v3, v4, v5,v6, v7)
-          set = fun struct(v1, v2, v3, v4, v5,v6, v7) _ -> ((((((v1, v2), v3), v4),v5),v6),v7) }
+        { get = fun struct(struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6),v7)-> struct(v1, v2, v3, v4, v5,v6, v7)
+          set = fun struct(v1, v2, v3, v4, v5,v6, v7) _ -> struct(struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6),v7) }
     /// Split a cons combination of 6 2-tuples into a 8-tuple
     let ofLeftTuple6(): DataLens<struct(struct(struct(struct(struct(struct(struct('v1 * 'v2) * 'v3) * 'v4)*'v5)*'v6)*'v7)*'v8), struct('v1 * 'v2 * 'v3 * 'v4 * 'v5 * 'v6 * 'v7 * 'v8)> =
-        { get = fun struct(struct(struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6),v7),v8)-> (v1, v2, v3, v4, v5,v6, v7,v8)
-          set = fun struct(v1, v2, v3, v4, v5,v6, v7,v8) _ -> (((((((v1, v2), v3), v4),v5),v6),v7),v8) }
+        { get = fun struct(struct(struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6),v7),v8)-> struct(v1, v2, v3, v4, v5,v6, v7,v8)
+          set = fun struct(v1, v2, v3, v4, v5,v6, v7,v8) _ -> struct(struct(struct(struct(struct(struct(struct(v1, v2), v3), v4),v5),v6),v7),v8) }
     /// Split a cons combination of 2 2-tuples into a 3-tuple
     let ofRightTuple(): DataLens<struct('v1 * struct('v2 * 'v3)), struct('v1 * 'v2 * 'v3)> =
-        { get = fun struct(v1, struct(v2, v3)) -> (v1, v2, v3)
-          set = fun struct(v1, v2, v3) _ -> (v1, (v2, v3)) }
+        { get = fun struct(v1, struct(v2, v3)) -> struct(v1, v2, v3)
+          set = fun struct(v1, v2, v3) _ -> struct(v1, struct(v2, v3)) }
     /// Unbox an untyped lens into a typed lens
     let internal unbox<'T, 'U> (l: DataLens): DataLens<'T, 'U> =
         { get = fun t -> unbox (l.get(box t))

--- a/src/With/DataLens.fs
+++ b/src/With/DataLens.fs
@@ -3,10 +3,11 @@ open System
 open With
 open System.ComponentModel
 
-type DataLensOptions(constructorAlias:string array)=
-    member __.ConstructorAlias = constructorAlias
-    static member Empty=DataLensOptions([||])
-
+module Internals=
+    type DataLensOptions = {ConstructorAlias:string list}
+    with
+        static member Empty={ConstructorAlias=[]}
+        static member Create a={ConstructorAlias=List.ofArray a}
 /// Copy of Lens definition from <a href="https://github.com/fsprojects/FSharpx.Extras/blob/master/src/FSharpx.Extras/Lens.fs">FSharpx.Extras</a>
 /// A lens is sort of like a property for immutable data on steroids.
 /// You can compose and combine lenses

--- a/src/With/Internals.fs
+++ b/src/With/Internals.fs
@@ -129,7 +129,7 @@ module internal InternalExpressions=
             let ityp = typedefof<IReadOnlyDictionary<_,_>>
             let ctorT (t:Type) = typ.MakeGenericType(t).GetTypeInfo().GetConstructors() |> Seq.find (fun c->c.GetParameters().Length =1)
 
-    let internal fieldOrPropertyToSetT (tSource: Type) (tDest: Type) (value: FieldOrProperty) =
+    let internal fieldOrPropertyToSetT (options:DataLensOptions) (tSource: Type) (tDest: Type) (value: FieldOrProperty) =
         /// compare parameter and field or property and make sure that they have the same Name (ignoring case)
         let haveSameName (p1:ParameterInfo) (p2:FieldOrProperty) =
             let p1Name = p1.Name

--- a/src/With/With.fsproj
+++ b/src/With/With.fsproj
@@ -6,18 +6,6 @@
     <AssemblyName>With</AssemblyName>
     <PackageId>With</PackageId>
 
-    <Authors>Oskar Gewalli</Authors>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/wallymathieu/with</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/wallymathieu/with.git</RepositoryUrl>
-    <PackageTags>copy;clone;with;Immutable;Extensions</PackageTags>
-
-    <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
-    <Description>Extensions to make c# easier to use when doing functional code. Copy update expressions. Helper extensions.</Description>
-    <Copyright>Copyright 2019</Copyright>
-
-    <PackageReleaseNotes>Trimmed down to what should be essential.</PackageReleaseNotes>
-
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
 
   </PropertyGroup>

--- a/tests/Tests/With/Clone_an_instance_with_property_of_property.cs
+++ b/tests/Tests/With/Clone_an_instance_with_property_of_property.cs
@@ -14,7 +14,7 @@ namespace Tests.With
             LensBuilder<Sale>.Of(sp => sp.Customer.Name).Build());
 
         [Theory, AutoData]
-        public void Should_be_able_to_create_a_clone_with_a_property_set_using_equalequal(Sale myClass, string newValue)
+        public void Should_be_able_to_create_a_clone_law_of_demeter(Sale myClass, string newValue)
         {
             var ret = CustomerNameCopy.Value.Set(myClass, newValue);
             Assert.Equal(newValue, ret.Customer.Name);
@@ -24,7 +24,7 @@ namespace Tests.With
             LensBuilder<Sale>.Of(sp=>sp.Customer).Then(c => c.Name).Build());
 
         [Theory, AutoData]
-        public void Should_be_able_to_create_a_clone_with_a_property_set_using_compose(Sale myClass, string newValue)
+        public void Should_be_able_to_create_a_clone_using_compose(Sale myClass, string newValue)
         {
             var ret = CustomerNameComposeCopy.Value.Set(myClass, newValue);
             Assert.Equal(newValue, ret.Customer.Name);

--- a/tests/Tests/With/Clone_with_constructor_methods.cs
+++ b/tests/Tests/With/Clone_with_constructor_methods.cs
@@ -1,0 +1,27 @@
+using System;
+using AutoFixture.Xunit2;
+using Tests.With.TestData;
+using With;
+using With.Lenses;
+using Xunit;
+
+namespace Tests.With
+{
+    public class Clone_with_constructor_methods
+    {
+        public Clone_with_constructor_methods ()
+        {
+        }
+        private static readonly Lazy<DataLens<CSale, string>> CustomerNameCopy = LazyT.Create (() =>
+            LensBuilder<CSale>.Constructors(new [] { "MK", "New"}).Of (sp => sp.Customer.Name).Build ());
+
+        [Theory, AutoData]
+        public void Should_be_able_to_create_a_clone_with_a_property_set_using_equalequal (CSale myClass, string newValue)
+        {
+            //var 
+            var ret = CustomerNameCopy.Value.Set (myClass, newValue);
+            Assert.Equal (newValue, ret.Customer.Name);
+            Assert.Equal (myClass.Id, ret.Id);
+        }
+    }
+}

--- a/tests/Tests/With/Clone_with_constructor_methods.cs
+++ b/tests/Tests/With/Clone_with_constructor_methods.cs
@@ -22,6 +22,8 @@ namespace Tests.With
             var ret = CustomerNameCopy.Value.Set (myClass, newValue);
             Assert.Equal (newValue, ret.Customer.Name);
             Assert.Equal (myClass.Id, ret.Id);
+            Assert.True (ret.FromMK, "from MK");
+            Assert.True (ret.Customer.FromNew, "from New");
         }
     }
 }

--- a/tests/Tests/With/Clone_with_constructor_methods.cs
+++ b/tests/Tests/With/Clone_with_constructor_methods.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using AutoFixture.Xunit2;
 using Tests.With.TestData;
 using With;
@@ -12,18 +13,44 @@ namespace Tests.With
         public Clone_with_constructor_methods ()
         {
         }
-        private static readonly Lazy<DataLens<CSale, string>> CustomerNameCopy = LazyT.Create (() =>
+        private static readonly Lazy<DataLens<CSale, string>> SaleCustomerNameCopy = LazyT.Create (() =>
             LensBuilder<CSale>.Constructors(new [] { "MK", "New"}).Of (sp => sp.Customer.Name).Build ());
 
         [Theory, AutoData]
-        public void Should_be_able_to_create_a_clone_with_a_property_set_using_equalequal (CSale myClass, string newValue)
+        public void Should_be_able_to_create_a_clone_law_of_demeter (CSale myClass, string newValue)
         {
-            //var 
-            var ret = CustomerNameCopy.Value.Set (myClass, newValue);
+            var ret = SaleCustomerNameCopy.Value.Set (myClass, newValue);
             Assert.Equal (newValue, ret.Customer.Name);
             Assert.Equal (myClass.Id, ret.Id);
             Assert.True (ret.FromMK, "from MK");
             Assert.True (ret.Customer.FromNew, "from New");
+        }
+        private static readonly Lazy<DataLens<ECCustomer, string>> CustomerNameCopy = LazyT.Create (() =>
+            LensBuilder<ECCustomer>.Constructors (new [] { "MK", "New" }).Of (sp => sp.Name).Build ());
+        private static readonly Lazy<DataLens<ECCustomer, IEnumerable<string>>> CustomerPrefCopy = LazyT.Create (() =>
+            LensBuilder<ECCustomer>.Constructors (new [] { "MK", "New" }).Of (sp => sp.Preferences).Build ());
+
+        [Theory, AutoData]
+        public void Should_get_correct_exception (int id, string newValue)
+        {
+            var ecc = ECCustomer.New (id, "name1", new string [0]);
+            var ret = CustomerNameCopy.Value.Set (ecc, newValue);
+            Assert.Equal (newValue, ret.Name);
+            Assert.True (ret.FromNew, "from New");
+            var ex=Assert.Throws<ArgumentNullException> (() => CustomerNameCopy.Value.Set (ecc, null));
+            Assert.Equal ("name", ex.ParamName);
+        }
+
+        [Theory, AutoData]
+        public void Should_get_correct_exception_2 (int id, string newValue)
+        {
+            var ecc = ECCustomer.New (id, "name1", new string [0]);
+            var prefs = new [] { newValue };
+            var ret = CustomerPrefCopy.Value.Set (ecc, prefs);
+            Assert.Equal (prefs, ret.Preferences);
+            Assert.True (ret.FromNew, "from New");
+            var ex = Assert.Throws<NullReferenceException> (() => CustomerPrefCopy.Value.Set (ecc, null));
+            Assert.Equal ("preferences", ex.Message);
         }
     }
 }

--- a/tests/Tests/With/TestData/CCustomer.cs
+++ b/tests/Tests/With/TestData/CCustomer.cs
@@ -5,6 +5,7 @@ namespace Tests.With.TestData
 {
     public class CCustomer
     {
+        public bool FromNew { get; private set; }
         private readonly int id;
         private readonly string name;
         private readonly IEnumerable<string> preferences;
@@ -13,13 +14,14 @@ namespace Tests.With.TestData
             this.id = id;
             this.name = name;
             this.preferences = preferences;
+            FromNew = false;
         }
         public int Id { get { return id; } private set { throw new Exception (); } }
         public string Name { get { return name; } private set { throw new Exception (); } }
         public IEnumerable<string> Preferences { get { return preferences; } private set { throw new Exception (); } }
         public static CCustomer New (int id, string name, IEnumerable<string> preferences)
         {
-            return new CCustomer (id, name, preferences);
+            return new CCustomer (id, name, preferences) { FromNew =true };
         }
     }
 }

--- a/tests/Tests/With/TestData/CCustomer.cs
+++ b/tests/Tests/With/TestData/CCustomer.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tests.With.TestData
+{
+    public class CCustomer
+    {
+        private readonly int id;
+        private readonly string name;
+        private readonly IEnumerable<string> preferences;
+        private CCustomer (int id, string name, IEnumerable<string> preferences)
+        {
+            this.id = id;
+            this.name = name;
+            this.preferences = preferences;
+        }
+        public int Id { get { return id; } private set { throw new Exception (); } }
+        public string Name { get { return name; } private set { throw new Exception (); } }
+        public IEnumerable<string> Preferences { get { return preferences; } private set { throw new Exception (); } }
+        public static CCustomer New (int id, string name, IEnumerable<string> preferences)
+        {
+            return new CCustomer (id, name, preferences);
+        }
+    }
+}

--- a/tests/Tests/With/TestData/CCustomer.cs
+++ b/tests/Tests/With/TestData/CCustomer.cs
@@ -24,4 +24,33 @@ namespace Tests.With.TestData
             return new CCustomer (id, name, preferences) { FromNew =true };
         }
     }
+    public class ECCustomer
+    {
+        public bool FromNew { get; private set; }
+        private readonly int id;
+        private readonly string name;
+        private readonly IEnumerable<string> preferences;
+        private ECCustomer (int id, string name, IEnumerable<string> preferences)
+        {
+            this.id = id;
+            this.name = name;
+            this.preferences = preferences;
+            FromNew = false;
+        }
+        public int Id { get { return id; } private set { throw new Exception (); } }
+        public string Name { get { return name; } private set { throw new Exception (); } }
+        public IEnumerable<string> Preferences { get { return preferences; } private set { throw new Exception (); } }
+        public static ECCustomer New (int id, string name, IEnumerable<string> preferences)
+        {
+            if (string.IsNullOrEmpty (name))
+            {
+                throw new ArgumentNullException (nameof(name));
+            }
+            if (preferences == null)
+            {
+                throw new NullReferenceException (nameof (preferences));
+            }
+            return new ECCustomer (id, name, preferences) { FromNew = true };
+        }
+    }
 }

--- a/tests/Tests/With/TestData/CSale.cs
+++ b/tests/Tests/With/TestData/CSale.cs
@@ -4,6 +4,7 @@ namespace Tests.With.TestData
 {
     public class CSale 
     {
+        public bool FromMK { get; private set; }
         private readonly int id;
         private readonly CCustomer customer;
         private Product product;
@@ -12,6 +13,7 @@ namespace Tests.With.TestData
             this.id = id;
             this.customer = customer;
             this.product = product;
+            FromMK = false;
         }
         public int Id { get { return id; } private set { throw new Exception (); } }
         public CCustomer Customer { get { return customer; } private set { throw new Exception (); } }
@@ -19,7 +21,7 @@ namespace Tests.With.TestData
         
         public static CSale MK(int id, CCustomer customer, Product product)
         {
-            return new CSale (id, customer, product);
+            return new CSale (id, customer, product) { FromMK =true };
         }
     }
 }

--- a/tests/Tests/With/TestData/CSale.cs
+++ b/tests/Tests/With/TestData/CSale.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Tests.With.TestData
+{
+    public class CSale 
+    {
+        private readonly int id;
+        private readonly CCustomer customer;
+        private Product product;
+        private CSale (int id, CCustomer customer, Product product)
+        {
+            this.id = id;
+            this.customer = customer;
+            this.product = product;
+        }
+        public int Id { get { return id; } private set { throw new Exception (); } }
+        public CCustomer Customer { get { return customer; } private set { throw new Exception (); } }
+        public Product Product { get { return product; } private set { throw new Exception (); } }
+        
+        public static CSale MK(int id, CCustomer customer, Product product)
+        {
+            return new CSale (id, customer, product);
+        }
+    }
+}

--- a/tests/TestsFs/Clone_an_instance_into_the_same_type.fs
+++ b/tests/TestsFs/Clone_an_instance_into_the_same_type.fs
@@ -16,7 +16,7 @@ type ``Clone an instance into the same type``()=
 
     [<Theory; AutoData>]
     member this.``A class should be able to create a clone with two property set using equal`` (myClass:Customer, newIntValue:int, newStrValue:string)=
-        let ret = idAndNameCopy.Value.Set(myClass,(newIntValue,newStrValue))
+        let ret = idAndNameCopy.Value.Set(myClass,struct(newIntValue,newStrValue))
         Assert.Equal(newIntValue, ret.id)
         Assert.Equal(newStrValue, ret.name)
 


### PR DESCRIPTION
Possible to do the following:

```c#
LensBuilder<Sale>.Constructors(new [] { "MK" }).Of (sp => sp.Customer.Name).Build ();
```

where `MK` is the constructor method name.  Any lenses defined during construction will then fall back on the `MK` static public method if any to construct entities. 